### PR TITLE
Remember last user inputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ Build with pyinstaller.bat
 build/
 dist/
 texconv/*
+config.ini
 
 # User-specific files (MonoDevelop/Xamarin Studio)
 *.userprefs

--- a/ACMOS.pyw
+++ b/ACMOS.pyw
@@ -14,6 +14,7 @@ from shutil import make_archive, move
 from glob import glob, escape
 from subprocess import check_call, CalledProcessError
 from datetime import datetime
+from configparser import ConfigParser
 
 from PIL import Image, UnidentifiedImageError
 
@@ -257,10 +258,12 @@ def set_lod_path():
         if answer:
             directory = directory.replace('/textures/terrain', '')
     btn_lod_path['text'] = directory
+    config['DEFAULT']['lod_path'] = directory
     sm(f'LOD Path set to {directory}')
     btn_generate['text'] = text['btn_generate'][language.get()]
     if btn_output_path['text'] == text['btn_lod_path'][language.get()]:
         btn_output_path['text'] = directory
+        config['DEFAULT']['output'] = directory
         sm(f'Output Path set to {directory}')
 
 def set_output_path():
@@ -273,9 +276,13 @@ def set_output_path():
         if answer:
             directory = directory.replace('/textures/terrain', '')
     btn_output_path['text'] = directory
+    config['DEFAULT']['output'] = directory
     sm(f'Output Path set to {directory}')
 
 def generate_button():
+    #Update configuration file before starting the process
+    config['DEFAULT']['roads'] = road_selection.get()
+    config.write(open('config.ini', 'w'))
     #What the generate button does
     btn_generate['state'] = 'disabled'
     if btn_lod_path['text'] == text['btn_lod_path'][language.get()]:
@@ -328,6 +335,7 @@ def generate_button():
 def change_language(lingo):
     #Language handling
     sm(f'Using {lingo}.', update_status = False)
+    config['DEFAULT']['language'] = lingo
     window.wm_title(text['title'][language.get()])
     lbl_roads_label['text'] = text['lbl_roads_label'][language.get()]
     lbl_lod_path_label['text'] = text['lbl_lod_path_label'][language.get()]
@@ -354,6 +362,17 @@ if __name__ == '__main__':
     with open('translate.json', encoding='utf-8') as translate_json:
         text = json.load(translate_json)
 
+    #Remember last used options or create a new config file
+    config = ConfigParser()
+    if exists('config.ini'):
+        config.read_file(open('config.ini'))
+    else:
+        config['DEFAULT'] = {'language': text['languages'][0],
+                             'roads': listdir('roads')[0],
+                             'lod_path': text['btn_lod_path'][text['languages'][0]],
+                             'output': text['btn_output_path'][text['languages'][0]]}
+        config.write(open('config.ini', 'x'))
+
     #Create base app window
     window = tk.Tk()
     icon = tk.PhotoImage(file='Icon.gif')
@@ -371,8 +390,8 @@ if __name__ == '__main__':
     #Language dropdown
     options = text['languages']
     language = tk.StringVar(window)
-    language.set(text['languages'][0])
-    optm_language = ttk.OptionMenu(window, language, text['languages'][0], *text['languages'], command=change_language)
+    language.set(config['DEFAULT']['language'])
+    optm_language = ttk.OptionMenu(window, language, config['DEFAULT']['language'], *text['languages'], command=change_language)
     optm_language.pack(padx=5, pady=5)
 
     #Road selection dropdown
@@ -380,20 +399,20 @@ if __name__ == '__main__':
     lbl_roads_label.pack(anchor=tk.NW, padx=5, pady=10, side=tk.LEFT)
     road_dirs = listdir(f'roads')
     road_selection = tk.StringVar(window)
-    road_selection.set(road_dirs[0])
-    optm_roads = ttk.OptionMenu(frame_roads, road_selection, road_dirs[0], *road_dirs)
+    road_selection.set(config['DEFAULT']['roads'])
+    optm_roads = ttk.OptionMenu(frame_roads, road_selection, config['DEFAULT']['roads'], *road_dirs)
     optm_roads.pack(anchor=tk.NW, padx=5, pady=9)
 
     #LOD Path widgets
     lbl_lod_path_label = tk.Label(frame_lod, text=text['lbl_lod_path_label'][language.get()])
     lbl_lod_path_label.pack(anchor=tk.NW, padx=5, pady=15, side=tk.LEFT)
-    btn_lod_path = tk.Button(frame_lod, text=text['btn_lod_path'][language.get()], command=set_lod_path)
+    btn_lod_path = tk.Button(frame_lod, text=config['DEFAULT']['lod_path'], command=set_lod_path)
     btn_lod_path.pack(anchor=tk.NW, padx=5, pady=10)
     
     #Output Path widgets
     lbl_output_path_label = tk.Label(frame_output, text=text['lbl_output_path_label'][language.get()])
     lbl_output_path_label.pack(anchor=tk.NW, padx=5, pady=15, side=tk.LEFT)
-    btn_output_path = tk.Button(frame_output, text=text['btn_output_path'][language.get()], command=set_output_path)
+    btn_output_path = tk.Button(frame_output, text=config['DEFAULT']['output'], command=set_output_path)
     btn_output_path.pack(anchor=tk.NW, padx=5, pady=10)
     
     #Generate button


### PR DESCRIPTION
Language, type of roads generation, LOD and Output paths are stored in config.ini file. So they are used as default values, when the program is restarted.

This is achieved by the Python in-built configparser module.

This is intended mainly for keeping language selection, but I extended it to every user-input value of the GUI.

The config.ini save happens after clicking "Generate" to minimize the code edit impact, maybe it could be a better solution.